### PR TITLE
Problemas al levantar zipkin server

### DIFF
--- a/zipkin.cmd
+++ b/zipkin.cmd
@@ -4,5 +4,3 @@ set STORAGE_TYPE=mysql
 set MYSQL_USER=zipkin
 set MYSQL_PASS=Andrea_1204
 java -jar ./zipkin-server-2.20.0-exec.jar
-
-set BASURA=Esta es una variable requerida y se modifica el valor


### PR DESCRIPTION
#Titulo

Hola, Al tratar de levantar el servidor zipkin se presenta un error y se ajusta el archivo zipkin.cmd y se elimina la variable BASURA del archivo, que insertaba un código de error 